### PR TITLE
Handling scenarios with N-level subdomains

### DIFF
--- a/certbot_dns_beget/_internal/dns_beget.py
+++ b/certbot_dns_beget/_internal/dns_beget.py
@@ -83,8 +83,12 @@ class _BegetClient(object):
         domainList = self._beget_api('/domain/getList', input_data)
         if domainList['status'] == 'success':
             for _domain in domainList['result']:
-                if _domain['fqdn'] == domain_name:
+                if domain_name.endswith(_domain['fqdn']):
                     domain = _domain
+
+            if domain == {}:
+                logger.error('The specified domain belonging to the Beget account could not be found')
+                raise errors.PluginError('The specified domain belonging to the Beget account could not be found')
 
             subdomainList = self._beget_api('/domain/getSubdomainList', input_data)
 
@@ -97,7 +101,7 @@ class _BegetClient(object):
                         isExist = True
                         break
             
-            subdomain = record_name.replace('.' + domain_name, '')
+            subdomain = record_name.replace('.' + domain['fqdn'], '')
             if isExist == False:
                 input_data = {
                     'subdomain' : subdomain,


### PR DESCRIPTION
This PR proposes to add the ability to create certificates for N-level subdomains (for example, xxx.yyy.domain.com). Previously, it was impossible to create a certificate for such a subdomain, since the Beget API provides a list of root domains (such as domain.com). Because of this, the `domain` variable in the `add_txt_record` method remained empty and this caused an error.